### PR TITLE
tx16s power

### DIFF
--- a/mLRS/Common/hal/esp/tx-hal-radiomaster-tx16s-2400-esp32.h
+++ b/mLRS/Common/hal/esp/tx-hal-radiomaster-tx16s-2400-esp32.h
@@ -200,15 +200,16 @@ IRAM_ATTR void esp_gpio0_low(void) { gpio_high(ESP_GPIO0); }
 
 //-- POWER
 // Need to confirm all of this!
-#define POWER_GAIN_DBM            18 // gain of a PA stage if present
-#define POWER_SX1280_MAX_DBM      SX1280_POWER_3_DBM  // maximum allowed sx power
+#define POWER_GAIN_DBM            26 // gain of a PA stage if present
+#define POWER_SX1280_MAX_DBM      SX1280_POWER_0_DBM  // maximum allowed sx power
 #define POWER_USE_DEFAULT_RFPOWER_CALC
 
-#define RFPOWER_DEFAULT           1 // index into rfpower_list array
+#define RFPOWER_DEFAULT           0 // index into rfpower_list array
 
 const rfpower_t rfpower_list[] = {
-    { .dbm = POWER_0_DBM, .mW = 1 },
     { .dbm = POWER_10_DBM, .mW = 10 },
+    { .dbm = POWER_17_DBM, .mW = 50 },
     { .dbm = POWER_20_DBM, .mW = 100 },
+    { .dbm = POWER_24_DBM, .mW = 250 },
 };
 


### PR DESCRIPTION
Previous power settings would've been around +8 dBm higher than expected.  This updates the SX power values to align with what the ELRS target uses.